### PR TITLE
Added wrappers for Struct, Value and ListValue

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -104,7 +104,6 @@ wrappers[".google.protobuf.Any"] = {
 // Custom wrapper for Struct
 wrappers[".google.protobuf.Struct"] = {
     fromObject: function(object) {
-        console.log('[DEBUG] Struct.fromObject called with:', object);
         // If already a Struct instance, return as is
         if (object instanceof this.ctor) return object;
         // Convert plain JS object to Struct
@@ -115,8 +114,11 @@ wrappers[".google.protobuf.Struct"] = {
                     fields[k] = this.lookup("Value").fromObject(object[k]);
                 }
             }
+
+            return this.create({ fields });
         }
-        return this.create({ fields });
+
+        return this.fromObject(object);
     },
     toObject: function(message, options) {
         // Convert Struct message to plain JS object
@@ -126,8 +128,10 @@ wrappers[".google.protobuf.Struct"] = {
             for (var k in message.fields) {
                 obj[k] = Value.toObject(message.fields[k], options);
             }
+            return obj;
         }
-        return obj;
+
+        return this.toObject(message, options);
     }
 };
 
@@ -166,8 +170,7 @@ wrappers[".google.protobuf.Value"] = {
             return this.create({ struct_value: Struct.fromObject(object) });
         }
         
-        // Fallback to null value for unknown types
-        return this.create({ null_value: 0 });
+        return this.fromObject(object);
     },
     toObject: function(message, options) {
         // Convert Value message to plain JS object
@@ -194,7 +197,8 @@ wrappers[".google.protobuf.Value"] = {
             var Struct = this.lookup("Struct");
             return Struct.toObject(message.struct_value, options);
         }
-        return null;
+
+        return this.toObject(message, options);
     }
 };
 
@@ -205,26 +209,30 @@ wrappers[".google.protobuf.ListValue"] = {
         if (object instanceof this.ctor) return object;
         
         // Convert array to ListValue
-        var values = [];
         if (Array.isArray(object)) {
+            var values = [];
             var Value = this.lookup("Value");
             for (var i = 0; i < object.length; i++) {
                 values.push(Value.fromObject(object[i]));
             }
+            var msg = this.create();
+            msg.values = values;
+            return msg;
         }
-        var msg = this.create();
-        msg.values = values;
-        return msg;
+
+        return this.fromObject(object);
     },
     toObject: function(message, options) {
         // Convert ListValue message to plain JS array
-        var values = [];
         if (message && message.values) {
+            var values = [];
             var Value = this.lookup("Value");
             for (var i = 0; i < message.values.length; i++) {
                 values.push(Value.toObject(message.values[i], options));
             }
+            return values;
         }
-        return values;
+
+        return this.toObject(message, options);
     }
 };

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -100,3 +100,131 @@ wrappers[".google.protobuf.Any"] = {
         return this.toObject(message, options);
     }
 };
+
+// Custom wrapper for Struct
+wrappers[".google.protobuf.Struct"] = {
+    fromObject: function(object) {
+        console.log('[DEBUG] Struct.fromObject called with:', object);
+        // If already a Struct instance, return as is
+        if (object instanceof this.ctor) return object;
+        // Convert plain JS object to Struct
+        var fields = {};
+        if (object && typeof object === "object" && !Array.isArray(object)) {
+            for (var k in object) {
+                if (object[k] !== undefined) {
+                    fields[k] = this.lookup("Value").fromObject(object[k]);
+                }
+            }
+        }
+        return this.create({ fields });
+    },
+    toObject: function(message, options) {
+        // Convert Struct message to plain JS object
+        var obj = {};
+        if (message && message.fields) {
+            var Value = this.lookup("Value");
+            for (var k in message.fields) {
+                obj[k] = Value.toObject(message.fields[k], options);
+            }
+        }
+        return obj;
+    }
+};
+
+// Custom wrapper for Value
+wrappers[".google.protobuf.Value"] = {
+    fromObject: function(object) {
+        // If already a Value instance, return as is
+        if (object instanceof this.ctor) return object;
+        
+        // Handle different types and convert to appropriate Value field
+        if (object === null || object === undefined) {
+            return this.create({ null_value: 0 });
+        }
+        
+        if (typeof object === "string") {
+            return this.create({ string_value: object });
+        }
+        
+        if (typeof object === "number") {
+            return this.create({ number_value: object });
+        }
+        
+        if (typeof object === "boolean") {
+            return this.create({ bool_value: object });
+        }
+        
+        if (Array.isArray(object)) {
+            // Use the ListValue wrapper's fromObject to ensure correct construction
+            var ListValue = this.lookup("ListValue");
+            return this.create({ list_value: ListValue.fromObject(object) });
+        }
+        
+        if (typeof object === "object") {
+            // Convert object to Struct
+            var Struct = this.lookup("Struct");
+            return this.create({ struct_value: Struct.fromObject(object) });
+        }
+        
+        // Fallback to null value for unknown types
+        return this.create({ null_value: 0 });
+    },
+    toObject: function(message, options) {
+        // Convert Value message to plain JS object
+        if (message.hasOwnProperty("null_value")) {
+            return null;
+        }
+        if (message.hasOwnProperty("string_value")) {
+            return message.string_value;
+        }
+        if (message.hasOwnProperty("number_value")) {
+            return message.number_value;
+        }
+        if (message.hasOwnProperty("bool_value")) {
+            return message.bool_value;
+        }
+        if (message.hasOwnProperty("list_value")) {
+            var values = [];
+            for (var i = 0; i < message.list_value.values.length; i++) {
+                values.push(wrappers[".google.protobuf.Value"].toObject.call(this, message.list_value.values[i], options));
+            }
+            return values;
+        }
+        if (message.hasOwnProperty("struct_value")) {
+            var Struct = this.lookup("Struct");
+            return Struct.toObject(message.struct_value, options);
+        }
+        return null;
+    }
+};
+
+// Custom wrapper for ListValue
+wrappers[".google.protobuf.ListValue"] = {
+    fromObject: function(object) {
+        // If already a ListValue instance, return as is
+        if (object instanceof this.ctor) return object;
+        
+        // Convert array to ListValue
+        var values = [];
+        if (Array.isArray(object)) {
+            var Value = this.lookup("Value");
+            for (var i = 0; i < object.length; i++) {
+                values.push(Value.fromObject(object[i]));
+            }
+        }
+        var msg = this.create();
+        msg.values = values;
+        return msg;
+    },
+    toObject: function(message, options) {
+        // Convert ListValue message to plain JS array
+        var values = [];
+        if (message && message.values) {
+            var Value = this.lookup("Value");
+            for (var i = 0; i < message.values.length; i++) {
+                values.push(Value.toObject(message.values[i], options));
+            }
+        }
+        return values;
+    }
+};


### PR DESCRIPTION
Added wrappers for conversion of Struct, Value and ListValue types for conversion between JS object and proto.
Proto spec for reference - https://protobuf.dev/reference/protobuf/google.protobuf/

Fixes - https://postmanlabs.atlassian.net/browse/APICLIENT-1720
Follow-ups - 
* Release new version of postmanlabs/protobufjs
* Update the modules that depend on this -
    * proto-loader
    * unified-runtime
    * postman-app