### PR TITLE
fix: fromObject unconditionally setting google.protobuf.NullValue fields, breaking oneof structures

### DIFF
--- a/src/converter.js
+++ b/src/converter.js
@@ -164,10 +164,14 @@ converter.fromObject = function fromObject(mtype) {
 
         // Non-repeated fields
         } else {
-            if (!(field.resolvedType instanceof Enum)) gen // no need to test for null/undefined if an enum (uses switch)
+            // Check for null/undefined for all fields except regular enums (which use switch).
+            // NullValue is special-cased to direct assignment, so it needs the null check too.
+            var needsNullCheck = !(field.resolvedType instanceof Enum) ||
+                (field.resolvedType && field.resolvedType.fullName === ".google.protobuf.NullValue");
+            if (needsNullCheck) gen
     ("if(d%s!=null){", prop); // !== undefined && !== null
         genValuePartial_fromObject(gen, field, /* not sorted */ i, prop);
-            if (!(field.resolvedType instanceof Enum)) gen
+            if (needsNullCheck) gen
     ("}");
         }
     } return gen

--- a/tests/comp_oneof-null_value.js
+++ b/tests/comp_oneof-null_value.js
@@ -1,0 +1,43 @@
+var tape = require("tape");
+
+var protobuf = require("..");
+
+var proto = 'syntax = "proto3";\
+import "google/protobuf/struct.proto";\
+message TestMessage {\
+    oneof payload {\
+        string text = 1;\
+        google.protobuf.NullValue nothing = 2;\
+    }\
+}';
+
+tape.test("NullValue in oneof", function(test) {
+    var root = new protobuf.Root();
+    root.addJSON(protobuf.common["google/protobuf/struct.proto"].nested);
+    protobuf.parse(proto, root);
+    root.resolveAll();
+    
+    var TestMessage = root.lookupType("TestMessage");
+    
+    var msg1 = TestMessage.fromObject({ text: "hello" });
+    test.equal(msg1.text, "hello", "should set text");
+    test.equal(msg1.payload, "text", "should set oneof to text");
+    test.notOk(msg1.hasOwnProperty("nothing"), "should not set nothing");
+    
+    var msg2 = TestMessage.fromObject({ nothing: "NULL_VALUE" });
+    test.equal(msg2.nothing, "NULL_VALUE", "should set nothing");
+    test.equal(msg2.payload, "nothing", "should set oneof to nothing");
+    test.notOk(msg2.hasOwnProperty("text"), "should not set text");
+    
+    var msg3 = TestMessage.fromObject({});
+    test.notOk(msg3.hasOwnProperty("text"), "empty: should not set text");
+    test.notOk(msg3.hasOwnProperty("nothing"), "empty: should not set nothing");
+    test.equal(msg3.payload, undefined, "empty: oneof should be undefined");
+    
+    var encoded = TestMessage.encode(msg1).finish();
+    var decoded = TestMessage.decode(encoded);
+    test.equal(decoded.text, "hello", "roundtrip: text preserved");
+    test.equal(decoded.payload, "text", "roundtrip: oneof preserved");
+
+    test.end();
+});


### PR DESCRIPTION
### Problem

The `fromObject` converter in `src/converter.js` has special handling for `google.protobuf.NullValue` enum that unconditionally assigns `"NULL_VALUE"` to the target message property.

When a `NullValue` field is part of a `oneof`, this unconditional assignment triggers the oneof behavior and clears any previously set fields in the same oneof block, even if the `NullValue` field was not present in the source object.

**Steps to Reproduce:**

```protobuf
syntax = "proto3";
import "google/protobuf/struct.proto";

message TestMessage {
  oneof payload {
    string text = 1;
    google.protobuf.NullValue nothing = 2;
  }
}
```

```javascript
const TestMessage = root.lookupType("TestMessage");
const message = TestMessage.fromObject({ text: "hello" });

// Before fix:
// message.text = undefined  (cleared by oneof!)
// message.nothing = "NULL_VALUE"
// message.payload = "nothing"

// After fix:
// message.text = "hello"
// message.nothing = undefined
// message.payload = "text"
```

### Root Cause

The original code assumed enums don't need a null check because they use a `switch` statement that handles missing values by not matching any branch. However, `NullValue` is special-cased to use direct assignment instead of a `switch`, so it was being set unconditionally.

### Solution

Add a null check for `NullValue` fields in the `fromObject` generator:

```javascript
var needsNullCheck = !(field.resolvedType instanceof Enum) ||
    (field.resolvedType && field.resolvedType.fullName === ".google.protobuf.NullValue");
if (needsNullCheck) gen("if(d%s!=null){", prop);
genValuePartial_fromObject(gen, field, i, prop);
if (needsNullCheck) gen("}");
```

### Testing

Added `tests/comp_oneof-null_value.js` covering:
- Setting non-NullValue field in oneof doesn't trigger NullValue assignment
- Explicitly setting NullValue works correctly  
- Empty objects don't set NullValue fields
- Encoding/decoding roundtrip works correctly

All existing tests pass.